### PR TITLE
attempt to fix the build by not uploading coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       # run tests!
       - run:
-          command: npm test
           command: npm run test-coverage
           # command: npm run test-ci
           # environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       # run tests!
       - run:
-          command: npm run test-ci
-          environment:
-            TEST_REPORTER_DOWNLOAD_URL: https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+          command: npm test
+          command: npm run test-coverage
+          # command: npm run test-ci
+          # environment:
+          #   TEST_REPORTER_DOWNLOAD_URL: https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
       - run: npm audit


### PR DESCRIPTION
## Issue

no issue

## What

temporary change to disable code coverage reporting because we don't have code climate setup in the new org yet. 

#14 will re-enable once we get VacasaOSS org setup with code climate

## Test
look at the build and verify that it ran tests and succeeded, also that test coverage output in the build console, but not reported to Code Climate
