### PR TITLE
Fix installation instructions typo. install as dev dependency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When the Lambda is invoked an AWS SDK call is used to decrypt the stored ciphert
 
 1. Create a custom KMS CMK.
 2. Upload secrets to SSM Parameter Store using the CMK
-3. Install this plugin with `npm install -s serveless-secret-baker`
+3. Install this plugin with `npm install --save-dev serverless-secret-baker`
 4. Add to your `serverless.yml` the following to install the plugin:
 
 ```


### PR DESCRIPTION


## Issue

none

## What

typo on readme in installation insructions
Install as dev dependency instead of prod dependency

## Test

Look at the readme, try the command, make sure it does what we expect.