### PR TITLE
Adding a 'tag' filter to the build job in the workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
   publish:
     jobs:
       - build
-          filters: &release-tag-only
+          filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - approve-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ workflows:
   publish:
     jobs:
       - build
+          filters: &release-tag-only
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
       - approve-publish:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
 workflows:
   publish:
     jobs:
-      - build
+      - build:
           filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
## Issue

#27 

## What

Fixes (hopefully) the build pipeline so that it will actually trigger the publish on tag events

## Test

Just watch the build, and look for the approve and publish steps when tagging.
