### PR TITLE
Adding support for specifying secrets using a list of strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ provider:
     MYSECRET: /path/to/ssm/secret
 ```
 
+Alternatively, if you would like to reference the secrets by their name in the
+parameter store you can specify the secrets as a list of strings.
+
+```
+provider:
+  environmentSecrets:
+    - MYSECRET
+```
+
+Which is equivalent to:
+
+```
+provider:
+  environmentSecrets:
+    MY_SECRET: MY_SECRET
+```
+
 The plugin will create a json file with all the secrets. In the above example the ciphertext and ARN of the secret located at `path/to/ssm/secret` will be stored in the file under the key `MYSECRET`.
 See example code in [examples](/examples) folder for reference.
 

--- a/README.md
+++ b/README.md
@@ -38,27 +38,11 @@ plugins:
 ```
 provider:
   environmentSecrets:
-    MYSECRET: /path/to/ssm/secret
-```
-
-Alternatively, if you would like to reference the secrets by their name in the
-parameter store you can specify the secrets as a list of strings.
-
-```
-provider:
-  environmentSecrets:
     - MY_SECRET
 ```
 
-Which is equivalent to:
+The plugin will create a json file with all the secrets. In the above example the ciphertext and ARN of the secret located at `MY_SECRET` will be stored in the file under the key `MY_SECRET`.
 
-```
-provider:
-  environmentSecrets:
-    MY_SECRET: MY_SECRET
-```
-
-The plugin will create a json file with all the secrets. In the above example the ciphertext and ARN of the secret located at `path/to/ssm/secret` will be stored in the file under the key `MYSECRET`.
 See example code in [examples](/examples) folder for reference.
 
 6. Ensure your Lambda has permission to decrypt the secret at runtime using the CMK. Example:
@@ -76,6 +60,39 @@ iamRoleStatements:
 
 - [Python Example](/examples/handler.py)
 - [Node Example](/examples/handler.js)
+
+## Advanced Configuration
+
+If you would like to name your secrets something different than the path in Parameter Store you can specify a name and path in the configuration like so:
+
+```
+provider:
+  environmentSecrets:
+    MY_SECRET: /path/to/ssm/secret
+```
+
+
+
+Or you can use a more explicit object syntax
+
+```
+provider:
+  environmentSecrets:
+    - name: CUSTOM_SECRET
+      path: a/custom/secret/path 
+```
+
+This allows you to mix styles
+
+```
+provider:
+  environmentSecrets:
+    - MY_SECRET
+    - MY_OTHER_SECRET
+    - name: CUSTOM_SECRET
+      path: a/custom/secret/path 
+```
+
 
 ## Why use this plugin?
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ parameter store you can specify the secrets as a list of strings.
 ```
 provider:
   environmentSecrets:
-    - MYSECRET
+    - MY_SECRET
 ```
 
 Which is equivalent to:

--- a/examples/handler.js
+++ b/examples/handler.js
@@ -22,11 +22,19 @@ async function decryptSecret(secretName) {
 }
 
 module.exports.hello = async (event, context) => {
+  const secrets = [
+    "MY_SECRET",
+    "MY_OTHER_SECRET",
+    "CUSTOM_SECRET"
+  ];
+  let output = "";
   try {
-    const secret = await decryptSecret("MYSECRET");
-
-    return `Secret MYSECRET: ${secret}`;
+    for (const secret of secrets) {
+        const value = await decryptSecret(secret);
+        output = output + `Secret ${secret}: ${value}\n`;
+    }
   } catch (error) {
     return `ERROR!: ${error}`;
   }
+  return output;
 };

--- a/examples/handler.py
+++ b/examples/handler.py
@@ -13,9 +13,15 @@ def kms_decrypt(secretName):
     resp = client.decrypt(CiphertextBlob=b64decode(secrets[secretName]["ciphertext"]), EncryptionContext=context)
     return resp['Plaintext'].decode('UTF-8')
 
+SECRETS = [
+    "MY_SECRET",
+    "MY_OTHER_SECRET",
+    "CUSTOM_SECRET",
+]
+
 def hello(event, context):
-    global warm_secret
-    if not warm_secret:
-        warm_secret = kms_decrypt("MYSECRET")
-    print(warm_secret)
-    return "OK"
+    output_builder = []
+    for secret in SECRETS:
+        value = kms_decrypt(secret)
+        output_builder.append("%s : %s\n" % (secret, value))
+    return "".join(output_builder)

--- a/examples/serverless.yml
+++ b/examples/serverless.yml
@@ -5,7 +5,10 @@ provider:
   runtime: nodejs8.10
   region: us-west-2
   environmentSecrets:
-    MYSECRET: test123
+    - MY_SECRET
+    - MY_OTHER_SECRET
+    - name: CUSTOM_SECRET
+      path: a/custom/secret/path
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/examples/serverless.yml
+++ b/examples/serverless.yml
@@ -8,7 +8,7 @@ provider:
     - MY_SECRET
     - MY_OTHER_SECRET
     - name: CUSTOM_SECRET
-      path: a/custom/secret/path
+      path: /a/custom/secret/path
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secret-baker",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secret-baker",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Serverless Plugin to store encrypted secrets from SSM as a packaged file availble to your lambdas.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Issue

#1 

## What

You can now specify only the ssm name for secrets as a list in the serverless.yml file

```
provider:
  environmentSecrets:
    - MY_SECRET
```

is equivalent to

```
provider:
  environmentSecrets:
    MY_SECRET: MY_SECRET
```

## Test

See the example above.  You should be able to create a secret in parameter store with a simple name like 'MY_SECRET', reference it in serverless.yml using the name 'MY_SECRET' in a list, and then reference it in your lambda using the name 'MY_SECRET'. 