### PR TITLE
Adding hooks so that lamdbas can be invoked locally with secrets.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -9,3 +9,7 @@ _Enter a description of changes performed here._
 ## Test
 
 _Enter test steps here._
+
+## Checks
+
+- [ ] Has the version number been incremented in package.json and package-lock.json

--- a/index.js
+++ b/index.js
@@ -18,7 +18,13 @@ class ServerlessSecretBaker {
       "before:deploy:function:packageFunction": this.packageSecrets.bind(this),
       "after:deploy:function:packageFunction": this.cleanupPackageSecrets.bind(
         this
-      )
+      ),
+      // For serverless-offline plugin
+      "before:offline:start:init": this.packageSecrets.bind(this),
+      "before:offline:start:end": this.cleanupPackageSecrets.bind(this),
+      // For invoke local
+      "before:invoke:local:invoke": this.packageSecrets.bind(this),
+      "after:invoke:local:invoke": this.cleanupPackageSecrets.bind(this)
     };
 
     this.options = options;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secret-baker",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secret-baker",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Serverless Plugin to store encrypted secrets from SSM as a packaged file availble to your lambdas.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Issue

#33 

## What

Adds hooks to the plugin that allow it to create and tear down secrets on local invocations, and using the `serverless-offline` plugin.

## Test

assuming myFunction uses secrets, then

`sls invoke local -f myFunction`

should work

