### PR TITLE
Bumping the version to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secret-baker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secret-baker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Serverless Plugin to store encrypted secrets from SSM as a packaged file availble to your lambdas.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Issue

Related to PR #36

## What

PR #36 was merged, but we forgot to bump the version number.  Added a note in the PR template to check that the version has been updated.  We have a check to make sure that the version is updated (I think), but it is only done when you attempt to publish.  Perhaps a check before merging the PR would be better. Also, worth talking about different release mechanisms (something akin to github flow).


