### PR TITLE
Option to disable cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ custom:
       path: a/custom/secret/path 
 ```
 
+### Preserve the encrypted secrets file
+
+The secrets files, `secret-baker-secrets.json`, is automatically generated at the start of
+every `serverless deploy`, `serverless package`, `serverless invoke local`, and
+`serverless offline` command. The secrets file, by default, will also be automatically removed
+upon command completion to not leave it in your source directory. 
+If you'd like to preserve the secrets file, pass in the CLI option `--no-secret-baker-cleanup`
 
 <p align="center">
 <img src="https://user-images.githubusercontent.com/4380779/63980303-fdd0a200-ca6f-11e9-99e8-8c2012b1c90f.png" width=250 />

--- a/index.js
+++ b/index.js
@@ -8,28 +8,33 @@ BbPromise.promisifyAll(fs);
 
 class ServerlessSecretBaker {
   constructor(serverless, options = {}) {
-    this.hooks = {
+    const pkgHooks = {
       "before:package:createDeploymentArtifacts": this.packageSecrets.bind(
         this
       ),
+      "before:deploy:function:packageFunction": this.packageSecrets.bind(this),
+      // For serverless-offline plugin
+      "before:offline:start": this.packageSecrets.bind(this),
+      // For invoke local
+      "before:invoke:local:invoke": this.packageSecrets.bind(this),
+    };
+
+    const cleanupHooks = {
       "after:package:createDeploymentArtifacts": this.cleanupPackageSecrets.bind(
         this
       ),
-      "before:deploy:function:packageFunction": this.packageSecrets.bind(this),
       "after:deploy:function:packageFunction": this.cleanupPackageSecrets.bind(
         this
       ),
       // For serverless-offline plugin
-      "before:offline:start": this.packageSecrets.bind(this),
       "before:offline:start:end": this.cleanupPackageSecrets.bind(this),
       // For invoke local
-      "before:invoke:local:invoke": this.packageSecrets.bind(this),
       "after:invoke:local:invoke": this.cleanupPackageSecrets.bind(this),
     };
 
-    if (!("secret-baker-cleanup" in options)) {
-      options["secret-baker-cleanup"] = true;
-    }
+    const shouldCleanup = options["secret-baker-cleanup"] != false;
+
+    this.hooks = shouldCleanup ? { ...pkgHooks, ...cleanupHooks } : pkgHooks;
     this.options = options;
     this.serverless = serverless;
   }
@@ -107,10 +112,8 @@ class ServerlessSecretBaker {
   }
 
   cleanupPackageSecrets() {
-    if (this.options["secret-baker-cleanup"]) {
-      this.serverless.cli.log(`Cleaning up ${secretsFile}`);
-      if (fs.existsSync(secretsFile)) fs.unlinkSync(secretsFile);
-    }
+    this.serverless.cli.log(`Cleaning up ${secretsFile}`);
+    if (fs.existsSync(secretsFile)) fs.unlinkSync(secretsFile);
   }
 
   packageSecrets() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secret-baker",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-secret-baker",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Serverless Framework Plugin for enabling secure and deterministic runtime decryption of secrets",
   "main": "index.js",
   "scripts": {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -59,6 +59,17 @@ describe("ServerlessSecretBaker", () => {
     expect(fs.unlinkSync).to.have.been.calledWith(SECRETS_FILE);
   });
 
+  it("should not clean up the correct secrets file with CLI option to not cleanup", () => {
+    const serverless = makeServerless();
+    const bakedGoods = new ServerlessSecretBaker(serverless, {
+      "secret-baker-cleanup": false,
+    });
+    fs.existsSync.returns(false);
+    fs.existsSync.withArgs(SECRETS_FILE).returns(true);
+    bakedGoods.cleanupPackageSecrets();
+    expect(fs.unlinkSync).to.not.have.been.called;
+  });
+
   it("should not clean up the secrets file if it does not exist", () => {
     const serverless = makeServerless();
     const bakedGoods = new ServerlessSecretBaker(serverless);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -66,8 +66,8 @@ describe("ServerlessSecretBaker", () => {
     });
     fs.existsSync.returns(false);
     fs.existsSync.withArgs(SECRETS_FILE).returns(true);
-    bakedGoods.cleanupPackageSecrets();
-    expect(fs.unlinkSync).to.not.have.been.called;
+    const cleanupFunction = bakedGoods.hooks["after:invoke:local:invoke"];
+    expect(cleanupFunction).to.be.undefined;
   });
 
   it("should not clean up the secrets file if it does not exist", () => {


### PR DESCRIPTION
## What

Adds an option of `--no-secret-baker-cleanup`.

This is helpful in a scenario where 1 long lived process is running `serverless offline` and other short lived processes are executing `serverless invoke local`.  Without this command there is potential for the short lived processes to remove the secrets file prior to `serverless offline` being able to load the file into memory.  

## Test

* Run `serverless invoke local --function X --no-secret-baker-cleanup`.  The `secret-baker-secrets.json` file is not auto-removed.  

## Checks

- [x] Has the version number been incremented in package.json and package-lock.json
